### PR TITLE
Implement buying and selling rates

### DIFF
--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -2,6 +2,8 @@
 name: M.H.M.U.
 tick: 30
 restock: 3600
+use_buying_rates: false
+use_selling_rates: false
 
 # sql
 hostname: 127.0.0.1

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,8 @@ options are passed as command line arguments.
 name: M.H.M.U. # Name that appears on AH when buying and selling
 tick: 30 # seconds between buying
 restock: 3600 # seconds between selling
+use_buying_rates: false  # Only buy items a fraction of the time?
+use_selling_rates: false  # Only sell items a fraction of the time?
 
 # sql
 hostname: 127.0.0.1 # SQL parameter
@@ -138,17 +140,19 @@ This command will remove all items for sale from the AH.
 
     This may result in exploits on your server if you are not careful.
 
-| column       | description                    | value             |
-| ------------ | ------------------------------ | ----------------- |
-| itemid       | unique item id                 | integer >=0       |
-| name         | item name                      | string            |
-| sell_single  | sell single?                   | 0=false 1=true    |
-| buy_single   | buy single?                    | 0=false 1=true    |
-| price_single | price for single               | integer >=1       |
-| stock_single | restock count (single)         | integer >=0       |
-| rate_single  | buy rate (single) **not used** | float 0 <= x <= 1 |
-| sell_stacks  | sell stack?                    | 0=false 1=true    |
-| buy_stacks   | buy stack?                     | 0=false 1=true    |
-| price_stacks | price for stack                | integer >=1       |
-| stock_stacks | restock count (stack)          | integer >=0       |
-| rate_stacks  | buy rate (stack) **not used**  | float 0 <= x <= 1 |
+| column           | description            | value             | note                                   |
+|------------------|------------------------|-------------------|----------------------------------------|
+| itemid           | unique item id         | integer >=0       |                                        |
+| name             | item name              | string            |                                        |
+| sell_single      | sell single?           | 0=false 1=true    |                                        |
+| buy_single       | buy single?            | 0=false 1=true    |                                        |
+| price_single     | price for single       | integer >=1       |                                        |
+| stock_single     | restock count (single) | integer >=0       |                                        |
+| sell_rate_single | sell rate (single)     | float 0 <= x <= 1 | disabled unless use_selling_rates=true |
+| buy_rate_single  | buy rate (single)      | float 0 <= x <= 1 | disabled unless use_buying_rates=true  |
+| sell_stacks      | sell stack?            | 0=false 1=true    |                                        |
+| buy_stacks       | buy stack?             | 0=false 1=true    |                                        |
+| price_stacks     | price for stack        | integer >=1       |                                        |
+| stock_stacks     | restock count (stack)  | integer >=0       |                                        |
+| sell_rate_stacks | sell rate (stack)      | float 0 <= x <= 1 | disabled unless use_selling_rates=true |
+| buy_rate_stacks  | buy rate (stack)       | float 0 <= x <= 1 | disabled unless use_buying_rates=true  |

--- a/ffxiahbot/apps/broker.py
+++ b/ffxiahbot/apps/broker.py
@@ -78,7 +78,7 @@ def main(
     if buy_items:
         buy_kwargs: dict[str, Any] = {} if not buy_immediately else {"next_run_time": datetime.now().astimezone()}
         scheduler.add_job(
-            lambda: manager.buy_items(item_list=item_list),
+            lambda: manager.buy_items(item_list=item_list, use_buying_rates=config.use_buying_rates),
             trigger="interval",
             id="buy_items",
             seconds=config.tick,
@@ -90,7 +90,7 @@ def main(
     if sell_items:
         sell_kwargs: dict[str, Any] = {} if not restock_immediately else {"next_run_time": datetime.now().astimezone()}
         scheduler.add_job(
-            lambda: manager.restock_items(item_list=item_list),
+            lambda: manager.restock_items(item_list=item_list, use_selling_rates=config.use_selling_rates),
             trigger="interval",
             id="restock_items",
             seconds=config.restock,

--- a/ffxiahbot/apps/refill.py
+++ b/ffxiahbot/apps/refill.py
@@ -58,5 +58,5 @@ def main(
 
     if no_prompt or confirm("Restock all items?", abort=True, show_default=True):
         logger.info("restocking...")
-        manager.restock_items(item_list=item_list)
+        manager.restock_items(item_list=item_list, use_selling_rates=config.use_selling_rates)
         logger.info("exit after restock")

--- a/ffxiahbot/config.py
+++ b/ffxiahbot/config.py
@@ -24,6 +24,8 @@ class Config(BaseModel):
     name: str = Field(default="M.H.M.U.")  # Bot name
     tick: int = Field(default=30)  # Tick interval (seconds)
     restock: int = Field(default=3600)  # Restock interval (seconds)
+    use_buying_rates: bool = Field(default=False)  # Only buy items a fraction of the time?
+    use_selling_rates: bool = Field(default=False)  # Only sell items a fraction of the time?
 
     # Database
     hostname: str = Field(default="127.0.0.1")  # SQL address

--- a/ffxiahbot/itemlist.py
+++ b/ffxiahbot/itemlist.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
-from ffxiahbot.item import Item, item_csv_title_str, item_csv_value_str
+from ffxiahbot.item import Item, allowed_item_keys, item_csv_title_str, item_csv_value_str
 from ffxiahbot.logutils import logger
 
 
@@ -181,7 +181,7 @@ class ItemList:
                     tokens: list[str | int | None] = [x.strip() for x in line.split(",")]
 
                     # check for new title line
-                    if set(tokens).issubset(Item.model_fields.keys()):
+                    if set(tokens).issubset(allowed_item_keys()):
                         keys = cast(list[str], tokens)
 
                         # check for primary key
@@ -189,7 +189,7 @@ class ItemList:
                             raise RuntimeError(f"missing itemid column:\n\t{keys}")
 
                     # validate line
-                    elif set(tokens).intersection(Item.model_fields.keys()):
+                    elif set(tokens).intersection(allowed_item_keys()):
                         raise RuntimeError("something wrong with line %d" % line_number)
 
                     # process normal line

--- a/tests/auction/test_manager.py
+++ b/tests/auction/test_manager.py
@@ -90,7 +90,7 @@ def test_buy_items(
 
     # perform buy loop multiple times
     for _ in range(3):
-        manager.buy_items(item_list)
+        manager.buy_items(item_list, use_buying_rates=False)
         assert manager.blacklist == expected_blacklist
 
     # validate database after buy loop
@@ -134,7 +134,7 @@ def test_restock_items(
 
     # perform restock loop multiple times
     for _ in range(3):
-        manager.restock_items(item_list)
+        manager.restock_items(item_list, use_selling_rates=False)
 
     # validate the historical prices after restock loop
     for itemid, (singles_price, stacks_price) in expected_history.items():

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,66 +1,51 @@
-import unittest
+from typing import Any
+
+import pytest
 
 from ffxiahbot.item import Item
 
 
-class TestCase01(unittest.TestCase):
-    def test_init(self):
-        i0 = Item(itemid=0, name="A")
-        self.assertEqual(i0.itemid, 0)
-        self.assertEqual(i0.name, "A")
-
-    def test_price_single(self):
-        Item(itemid=0, price_single=+1)
-        with self.assertRaises(ValueError):
-            Item(itemid=0, price_single=+0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, price_single=-1)
-
-    def test_price_stacks(self):
-        Item(itemid=0, price_stacks=+1)
-        with self.assertRaises(ValueError):
-            Item(itemid=0, price_stacks=+0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, price_stacks=-1)
-
-    def test_stock_single(self):
-        Item(itemid=0, stock_single=+0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, stock_single=-1)
-
-    def test_stock_stacks(self):
-        Item(itemid=0, stock_stacks=+0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, stock_stacks=-1)
-
-    def test_rate_single(self):
-        i = Item(itemid=0)
-        self.assertEqual(i.rate_single, 1.0)
-
-        Item(itemid=0, rate_single=0.0)
-        Item(itemid=0, rate_single=0.5)
-        Item(itemid=0, rate_single=1.0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, rate_single=-1.5)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, rate_single=+1.5)
-
-    def test_rate_stacks(self):
-        i = Item(itemid=0)
-        self.assertEqual(i.rate_stacks, 1.0)
-
-        Item(itemid=0, rate_stacks=0.0)
-        Item(itemid=0, rate_stacks=0.5)
-        Item(itemid=0, rate_stacks=1.0)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, rate_stacks=-1.5)
-
-        with self.assertRaises(ValueError):
-            Item(itemid=0, rate_stacks=+1.5)
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        pytest.param({"itemid": 0, "name": "A"}, None, id="name=A"),
+        pytest.param({"itemid": 0, "price_single": 1}, None, id="price_single=1"),
+        pytest.param({"itemid": 0, "price_single": 0}, ValueError, id="price_single=0 raises"),
+        pytest.param({"itemid": 0, "price_single": -1}, ValueError, id="price_single=-1 raises"),
+        pytest.param({"itemid": 0, "price_stacks": 1}, None, id="price_stacks=1"),
+        pytest.param({"itemid": 0, "price_stacks": 0}, ValueError, id="price_stacks=0 raises"),
+        pytest.param({"itemid": 0, "price_stacks": -1}, ValueError, id="price_stacks=-1 raises"),
+        pytest.param({"itemid": 0, "stock_single": 0}, None, id="stock_single=0"),
+        pytest.param({"itemid": 0, "stock_single": -1}, ValueError, id="stock_single=-1"),
+        pytest.param({"itemid": 0, "stock_stacks": 0}, None, id="stock_stacks=0"),
+        pytest.param({"itemid": 0, "stock_stacks": -1}, ValueError, id="stock_stacks=-1"),
+        pytest.param({"itemid": 0, "sell_rate_single": 0.0}, None, id="sell_rate_single=0.0"),
+        pytest.param({"itemid": 0, "sell_rate_single": 0.5}, None, id="sell_rate_single=0.5"),
+        pytest.param({"itemid": 0, "sell_rate_single": 1.0}, None, id="sell_rate_single=1.0"),
+        pytest.param({"itemid": 0, "sell_rate_single": -1.5}, ValueError, id="sell_rate_single=-1.5"),
+        pytest.param({"itemid": 0, "sell_rate_single": +1.5}, ValueError, id="sell_rate_single=+1.5"),
+        pytest.param({"itemid": 0, "sell_rate_stacks": 0.0}, None, id="sell_rate_stacks=0.0"),
+        pytest.param({"itemid": 0, "sell_rate_stacks": 0.5}, None, id="sell_rate_stacks=0.5"),
+        pytest.param({"itemid": 0, "sell_rate_stacks": 1.0}, None, id="sell_rate_stacks=1.0"),
+        pytest.param({"itemid": 0, "sell_rate_stacks": -1.5}, ValueError, id="sell_rate_stacks=-1.5"),
+        pytest.param({"itemid": 0, "sell_rate_stacks": +1.5}, ValueError, id="sell_rate_stacks=+1.5"),
+        pytest.param({"itemid": 0, "buy_rate_single": 0.0}, None, id="buy_rate_single=0.0"),
+        pytest.param({"itemid": 0, "buy_rate_single": 0.5}, None, id="buy_rate_single=0.5"),
+        pytest.param({"itemid": 0, "buy_rate_single": 1.0}, None, id="buy_rate_single=1.0"),
+        pytest.param({"itemid": 0, "buy_rate_single": -1.5}, ValueError, id="buy_rate_single=-1.5"),
+        pytest.param({"itemid": 0, "buy_rate_single": +1.5}, ValueError, id="buy_rate_single=+1.5"),
+        pytest.param({"itemid": 0, "buy_rate_stacks": 0.0}, None, id="buy_rate_stacks=0.0"),
+        pytest.param({"itemid": 0, "buy_rate_stacks": 0.5}, None, id="buy_rate_stacks=0.5"),
+        pytest.param({"itemid": 0, "buy_rate_stacks": 1.0}, None, id="buy_rate_stacks=1.0"),
+        pytest.param({"itemid": 0, "buy_rate_stacks": -1.5}, ValueError, id="buy_rate_stacks=-1.5"),
+        pytest.param({"itemid": 0, "buy_rate_stacks": +1.5}, ValueError, id="buy_rate_stacks=+1.5"),
+    ],
+)
+def test_create_item_raises(kwargs: dict[str, Any], error: type[Exception] | None):
+    if error:
+        with pytest.raises(error):
+            Item(**kwargs)
+    else:
+        item = Item(**kwargs)
+        for key, value in kwargs.items():
+            assert getattr(item, key) == value

--- a/tests/test_itemlist.py
+++ b/tests/test_itemlist.py
@@ -55,6 +55,8 @@ class TestCase01(unittest.TestCase):
         "stock_stacks": 40,
         "rate_single": 0.5,
         "rate_stacks": 0.6,
+        "buy_rate_single": 0.7,
+        "buy_rate_stacks": 0.8,
     }
 
     def test_save_csv(self):


### PR DESCRIPTION
When `use_buying_rates=true` in the config file, only buy a fraction of the time.
This fraction is set per item in the CSV using `buy_rate_single` and `buy_rate_stacks`.

When `use_selling_rates=true` in the config file, only sell a fraction of the time.
This fraction is set per item in the CSV using `sell_rate_single` and `sell_rate_stacks`.