### PR TITLE
Fix next_run_time argument

### DIFF
--- a/ffxiahbot/apps/broker.py
+++ b/ffxiahbot/apps/broker.py
@@ -95,7 +95,6 @@ def main(
             id="restock_items",
             seconds=config.restock,
             max_instances=1,
-            next_run_time=None if not restock_immediately else datetime.now().astimezone(),
             name="Restock Items",
             **sell_kwargs,
         )


### PR DESCRIPTION
When next_run_time=None, the job is paused. This caused restock job to never
trigger.
